### PR TITLE
Remove collectd_hostname attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ An Ansible role for installing [Collectd](http://collectd.org).
 ## Role Variables
 
 - `collectd_version` - Collectd version
-- `collectd_hostname` - Collectd hostname (default: `localhost`)
 - `collectd_interval` - Collectd metrics collection interval (default: `10`)
 - `collectd_load_plugins` - Collectd plugins to load (see [defaults](./defaults/main.yml]))
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
 collectd_version: "5.4.0-3ubuntu2"
-collectd_hostname: localhost
 collectd_interval: 10
 collectd_load_plugins: []

--- a/templates/collectd.conf.j2
+++ b/templates/collectd.conf.j2
@@ -6,7 +6,6 @@
 # You should also read /usr/share/doc/collectd-core/README.Debian.plugins
 # before enabling any more plugins.
 
-Hostname "{{ collectd_hostname }}"
 FQDNLookup true
 #BaseDir "/var/lib/collectd"
 #PluginDir "/usr/lib/collectd"


### PR DESCRIPTION
`collectd_hostname` was being used to populate the Collectd configuration file's `Hostname` setting. If omitted, Collectd uses the `gethostname(2)` system call to automatically set `Hostname`. This behavior is much more desirable, especially in dynamic environments like EC2.
