### PR TITLE
Add support for installing recommended dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An Ansible role for installing [Collectd](http://collectd.org).
 ## Role Variables
 
 - `collectd_version` - Collectd version
+- `collectd_install_recommends` - A flag passed to the `install_recommends` option of the Ansible `apt` module (default: `True`).
 - `collectd_interval` - Collectd metrics collection interval (default: `10`)
 - `collectd_load_plugins` - Collectd plugins to load (see [defaults](./defaults/main.yml))
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 collectd_version: "5.4.0-3ubuntu2"
+collectd_install_recommends: True
 collectd_interval: 10
 collectd_load_plugins: []

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -1,4 +1,9 @@
 ---
 - hosts: all
+
+  pre_tasks:
+    - name: Update APT cache
+      apt: update_cache=yes
+
   roles:
     - { role: "azavea.collectd" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Install Collectd
-  apt: pkg=collectd={{ collectd_version }} state=present
+  apt: pkg=collectd={{ collectd_version }}
+       install_recommends={{ collectd_install_recommends }}
+       state=present
 
 - name: Configure Collectd
   template: src=collectd.conf.j2 dest=/etc/collectd/collectd.conf


### PR DESCRIPTION
This changeset adds a `collectd_install_recommends` variable that is passed to the `install_recommends` option of the Ansible `apt` module. The default for `install_recommends` has been `True`, so the default for this role is also `True`.

See also: http://docs.ansible.com/apt_module.html
