### PR TITLE
Add apt update option prior to collectd installation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@ collectd_version: "5.4.0-3ubuntu2"
 collectd_install_recommends: True
 collectd_interval: 10
 collectd_load_plugins: []
+collectd_update_cache: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   apt: pkg=collectd={{ collectd_version }}
        install_recommends={{ collectd_install_recommends }}
        state=present
+       update_cache={{ collectd_update_cache }}
 
 - name: Configure Collectd
   template: src=collectd.conf.j2 dest=/etc/collectd/collectd.conf


### PR DESCRIPTION
Default behaviour continues to be the same: no apt cache update.
This has proven useful when deploying collectd in out of date machines.
