### PR TITLE
--force-yes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   apt: pkg=collectd={{ collectd_version }}
        install_recommends={{ collectd_install_recommends }}
        state=present
+       force=yes
 
 - name: Configure Collectd
   template: src=collectd.conf.j2 dest=/etc/collectd/collectd.conf


### PR DESCRIPTION
Because it is failing our provisioning right now

```
TASK: [collectd | Install Collectd] *******************************************
failed: [11.0.1.126] => {"failed": true}
stderr: E: There are problems and -y was used without --force-yes

stdout: Reading package lists...
Building dependency tree...
Reading state information...
The following packages were automatically installed and are no longer required:
  linux-headers-3.13.0-36 linux-headers-3.13.0-36-generic
  linux-headers-3.13.0-65 linux-headers-3.13.0-65-generic
  linux-headers-3.13.0-67 linux-headers-3.13.0-67-generic
  linux-headers-3.13.0-68 linux-headers-3.13.0-68-generic
  linux-image-3.13.0-36-generic linux-image-3.13.0-65-generic
  linux-image-3.13.0-67-generic linux-image-3.13.0-68-generic
Use 'apt-get autoremove' to remove them.
The following packages will be DOWNGRADED:
  collectd
0 upgraded, 0 newly installed, 1 downgraded, 0 to remove and 0 not upgraded.
Need to get 16.4 kB of archives.
After this operation, 1024 B disk space will be freed.

msg: '/usr/bin/apt-get -y -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold"   install 'collectd=5.4.0-3ubuntu2'' failed: E: There are problems and -y was used without --force-yes


FATAL: all hosts have already failed -- aborting
```
